### PR TITLE
fix: add pause container to DPU cluster

### DIFF
--- a/charts/nfs-csi-controller/templates/dpu-daemonset.yaml
+++ b/charts/nfs-csi-controller/templates/dpu-daemonset.yaml
@@ -1,0 +1,60 @@
+{{- if and .Values.dpu.enabled .Values.dpu.dummyDaemonSet.enabled }}
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: {{ include "nfs-csi-controller.fullname" . }}-dpu
+  labels:
+    {{- include "nfs-csi-controller.labels" . | nindent 4 }}
+    {{- with .Values.serviceDaemonSet.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+  annotations:
+    {{- with .Values.serviceDaemonSet.annotations }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  {{- with .Values.serviceDaemonSet.updateStrategy }}
+  updateStrategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "nfs-csi-controller.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "nfs-csi-controller.selectorLabels" . | nindent 8 }}
+        {{- with .Values.serviceDaemonSet.labels }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
+      annotations:
+        {{- with .Values.serviceDaemonSet.annotations }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.dpu.dummyDaemonSet.imagePullSecrets | default .Values.imagePullSecrets | default list }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.dpu.dummyDaemonSet.podSecurityContext | nindent 8 }}
+      hostNetwork: {{ .Values.dpu.dummyDaemonSet.hostNetwork }}
+      containers:
+        - name: pause
+          image: "{{ .Values.dpu.dummyDaemonSet.pause.image.repository }}:{{ .Values.dpu.dummyDaemonSet.pause.image.tag }}"
+          imagePullPolicy: {{ .Values.dpu.dummyDaemonSet.pause.imagePullPolicy }}
+          securityContext:
+            {{- toYaml .Values.dpu.dummyDaemonSet.pause.securityContext | nindent 12 }}
+      terminationGracePeriodSeconds: {{ .Values.dpu.dummyDaemonSet.terminationGracePeriodSeconds }}
+      {{- with toYaml .Values.serviceDaemonSet.nodeSelector }}
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+              {{- . | nindent 12 }}
+      {{- end }}
+      {{- with .Values.dpu.dummyDaemonSet.tolerations | default list }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/charts/nfs-csi-controller/templates/dpu-rbac.yaml
+++ b/charts/nfs-csi-controller/templates/dpu-rbac.yaml
@@ -1,13 +1,5 @@
 {{- if and .Values.dpu.enabled .Values.dpu.rbacRoles.nfsCsiController.create }}
 ---
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: {{ .Values.dpu.rbacRoles.nfsCsiController.serviceAccount }}
-  namespace: {{ .Release.Namespace }}
-  labels:
-    {{- include "nfs-csi-controller.labels" . | nindent 4 }}
----
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/charts/nfs-csi-controller/values.yaml
+++ b/charts/nfs-csi-controller/values.yaml
@@ -1,3 +1,32 @@
+####################
+### DPF contract ###
+####################
+
+# configuration for the service
+serviceDaemonSet:
+  # selects nodes on which this service will run by label. Can be set in DPUService `.spec.serviceDaemonSet.nodeSelector`
+  # nodeSelector:
+  #   nodeSelectorTerms:
+  #   - matchExpressions:
+  #       - key: dpu
+  #         operator: In
+  #         values:
+  #           - dpu
+  # labels on the DaemonSet and pod template. Can be set in DPUService `.spec.serviceDaemonSet.labels`
+  labels: {}
+  # annotations on the DaemonSet and pod template. Can be set in DPUService `.spec.serviceDaemonSet.annotations`
+  annotations: {}
+  # updateStrategy on the DaemonSet. Can be set in DPUService `.spec.serviceDaemonSet.updateStrategy.`
+  updateStrategy: {}
+  #  type: RollingUpdate
+  #  rollingUpdate:
+  #    maxUnavailable: 1
+  # resources on the DaemonSet and pod template. Can be set in DPUService `.spec.serviceDaemonSet.resources`
+  resources: {}
+
+# default imagePullSecrets
+imagePullSecrets: []
+
 #====================================================
 # Settings for the host cluster portion of the chart
 #====================================================
@@ -169,3 +198,19 @@ dpu:
     nfsCsiController:
       create: true
       serviceAccount: nfs-csi-controller-sa
+  # Create a dummy DaemonSet on the DPU.
+  # This is a workaround for the logic in the DPU Ready Controller that expects a pod for each DPUService.
+  dummyDaemonSet:
+    enabled: true
+    podSecurityContext: {}
+    tolerations: []
+    hostNetwork: true
+    imagePullSecrets: []
+    pause:
+      imagePullPolicy: IfNotPresent
+      image:
+        repository: "registry.k8s.io/pause"
+        tag: "3.10"
+      securityContext:
+        allowPrivilegeEscalation: false
+    terminationGracePeriodSeconds: 10

--- a/charts/spdk-csi-controller/templates/dpu-daemonset.yaml
+++ b/charts/spdk-csi-controller/templates/dpu-daemonset.yaml
@@ -1,0 +1,60 @@
+{{- if and .Values.dpu.enabled .Values.dpu.dummyDaemonSet.enabled }}
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: {{ include "spdk-csi-controller.fullname" . }}-dpu
+  labels:
+    {{- include "spdk-csi-controller.labels" . | nindent 4 }}
+    {{- with .Values.serviceDaemonSet.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+  annotations:
+    {{- with .Values.serviceDaemonSet.annotations }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  {{- with .Values.serviceDaemonSet.updateStrategy }}
+  updateStrategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "spdk-csi-controller.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "spdk-csi-controller.selectorLabels" . | nindent 8 }}
+        {{- with .Values.serviceDaemonSet.labels }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
+      annotations:
+        {{- with .Values.serviceDaemonSet.annotations }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.dpu.dummyDaemonSet.imagePullSecrets | default .Values.imagePullSecrets | default list }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.dpu.dummyDaemonSet.podSecurityContext | nindent 8 }}
+      hostNetwork: {{ .Values.dpu.dummyDaemonSet.hostNetwork }}
+      containers:
+        - name: pause
+          image: "{{ .Values.dpu.dummyDaemonSet.pause.image.repository }}:{{ .Values.dpu.dummyDaemonSet.pause.image.tag }}"
+          imagePullPolicy: {{ .Values.dpu.dummyDaemonSet.pause.imagePullPolicy }}
+          securityContext:
+            {{- toYaml .Values.dpu.dummyDaemonSet.pause.securityContext | nindent 12 }}
+      terminationGracePeriodSeconds: {{ .Values.dpu.dummyDaemonSet.terminationGracePeriodSeconds }}
+      {{- with toYaml .Values.serviceDaemonSet.nodeSelector }}
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+              {{- . | nindent 12 }}
+      {{- end }}
+      {{- with .Values.dpu.dummyDaemonSet.tolerations | default list }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/charts/spdk-csi-controller/values.yaml
+++ b/charts/spdk-csi-controller/values.yaml
@@ -1,3 +1,33 @@
+####################
+### DPF contract ###
+####################
+
+# configuration for the service
+serviceDaemonSet:
+  # selects nodes on which this service will run by label. Can be set in DPUService `.spec.serviceDaemonSet.nodeSelector`
+  # nodeSelector:
+  #   nodeSelectorTerms:
+  #   - matchExpressions:
+  #       - key: dpu
+  #         operator: In
+  #         values:
+  #           - dpu
+  # labels on the DaemonSet and pod template. Can be set in DPUService `.spec.serviceDaemonSet.labels`
+  labels: {}
+  # annotations on the DaemonSet and pod template. Can be set in DPUService `.spec.serviceDaemonSet.annotations`
+  annotations: {}
+  # updateStrategy on the DaemonSet. Can be set in DPUService `.spec.serviceDaemonSet.updateStrategy.`
+  updateStrategy: {}
+  #  type: RollingUpdate
+  #  rollingUpdate:
+  #    maxUnavailable: 1
+  # resources on the DaemonSet and pod template. Can be set in DPUService `.spec.serviceDaemonSet.resources`
+  resources: {}
+
+# default imagePullSecrets
+imagePullSecrets: []
+
+
 #====================================================
 # Settings for the host cluster portion of the chart
 #====================================================
@@ -105,3 +135,19 @@ dpu:
     spdkCsiController:
       create: true
       serviceAccount: spdk-csi-controller-sa
+  # Create a dummy DaemonSet on the DPU.
+  # This is a workaround for the logic in the DPU Ready Controller that expects a pod for each DPUService.
+  dummyDaemonSet:
+    enabled: true
+    podSecurityContext: {}
+    tolerations: []
+    hostNetwork: true
+    imagePullSecrets: []
+    pause:
+      imagePullPolicy: IfNotPresent
+      image:
+        repository: "registry.k8s.io/pause"
+        tag: "3.10"
+      securityContext:
+        allowPrivilegeEscalation: false
+    terminationGracePeriodSeconds: 10


### PR DESCRIPTION
Add pause container to the DPU cluster.
This pause container acts as a workaround
for the limitation in the DPU Ready Controller that
currently requires each DPUService to have a Pod on the DPU.